### PR TITLE
Point Cloud Layers Support

### DIFF
--- a/core/FileFormatConfiguration.py
+++ b/core/FileFormatConfiguration.py
@@ -49,8 +49,8 @@ RASTER_FORMATS = [
 ]
 
 POINT_CLOUD_FORMATS = [
-    ("COPC Point Clouds (*.copc.laz *.COPC.LAZ)", [".copc.laz", ".COPC.LAZ"]),
-    ("Entwine Point Clouds (*.ept.json *.EPT.JSON)", [".ept.json", ".EPT.JSON"]),
-    ("PDAL Point Clouds (*.bpf *.e57 *.las *.laz)", [".bpf", ".e57", ".las", ".laz", ".BPF", ".E57", ".LAS", ".LAZ"]),
-    ("Virtual Point Clouds (*.vpc *.VPC )", [".vpc", ".VPC"]),
+    ("COPC Point Clouds (*.copc.laz *.COPC.LAZ)", [".copc.laz"]),
+    ("Entwine Point Clouds (*.ept.json *.EPT.JSON)", [".ept.json"]),
+    ("PDAL Point Clouds (*.bpf *.e57 *.las *.laz)", [".bpf", ".e57", ".las", ".laz"]),
+    ("Virtual Point Clouds (*.vpc *.VPC )", [".vpc"]),
 ]

--- a/core/FileFormatConfiguration.py
+++ b/core/FileFormatConfiguration.py
@@ -47,3 +47,10 @@ RASTER_FORMATS = [
     ("Multi-resolution Seamless Image Database (*.sid)", [".sid"]),
     ("BSB Nautical Chart Format (*.kap)", [".kap"]),
 ]
+
+POINT_CLOUD_FORMATS = [
+    ("COPC Point Clouds (*.copc.laz *.COPC.LAZ)", [".copc.laz", ".COPC.LAZ"]),
+    ("Entwine Point Clouds (*.ept.json *.EPT.JSON)", [".ept.json", ".EPT.JSON"]),
+    ("PDAL Point Clouds (*.bpf *.e57 *.las *.laz)", [".bpf", ".e57", ".las", ".laz", ".BPF", ".E57", ".LAS", ".LAZ"]),
+    ("Virtual Point Clouds (*.vpc *.VPC )", [".vpc", ".VPC"]),
+]

--- a/core/Filter.py
+++ b/core/Filter.py
@@ -27,6 +27,7 @@ from qgis.PyQt.QtCore import QDateTime
 from qgis.core import (QgsRectangle,
                        QgsWkbTypes)
 
+from .LayerTypes import LayerType
 from .Utils import (get_raster_layer,
                     get_vector_layer,
                     get_point_cloud_layer)
@@ -147,9 +148,9 @@ class InvertedAlphanumericFilter(Filter):
 
 class BoundingBoxFilter(Filter):
     """ Filter based on a bounding box """
-    def __init__(self, layerType, boundingBox, method):
+    def __init__(self, layerType: LayerType, boundingBox, method):
         """
-        :param layerType: "raster" or "vector"
+        :param layerType: LayerType enum
         :type string:
         :param boundingBox: The bounding box for selection
         :type QgsRectangle:
@@ -163,13 +164,13 @@ class BoundingBoxFilter(Filter):
     def apply(self, layer_path, layer_dict):
         """ Apply the bounding box filter """
 
-        if self.layerType == "vector":
+        if self.layerType == LayerType.VECTOR:
             if layer_dict[layer_path] is None:
                 layer_dict[layer_path] = get_vector_layer(layer_path, '', layer_dict)
-        elif self.layerType == "raster":
+        elif self.layerType == LayerType.RASTER:
             if layer_dict[layer_path] is None:
                 layer_dict[layer_path] = get_raster_layer(layer_path, '', layer_dict)
-        elif self.layerType == "pointcloud":
+        elif self.layerType == LayerType.POINTCLOUD:
             if layer_dict[layer_path] is None:
                 layer_dict[layer_path] = get_point_cloud_layer(layer_path, '', layer_dict)
 

--- a/core/Filter.py
+++ b/core/Filter.py
@@ -28,7 +28,8 @@ from qgis.core import (QgsRectangle,
                        QgsWkbTypes)
 
 from .Utils import (get_raster_layer,
-                    get_vector_layer)
+                    get_vector_layer,
+                    get_point_cloud_layer)
 
 
 class Filter(ABC):
@@ -165,9 +166,12 @@ class BoundingBoxFilter(Filter):
         if self.layerType == "vector":
             if layer_dict[layer_path] is None:
                 layer_dict[layer_path] = get_vector_layer(layer_path, '', layer_dict)
-        else:
+        elif self.layerType == "raster":
             if layer_dict[layer_path] is None:
                 layer_dict[layer_path] = get_raster_layer(layer_path, '', layer_dict)
+        elif self.layerType == "pointcloud":
+            if layer_dict[layer_path] is None:
+                layer_dict[layer_path] = get_point_cloud_layer(layer_path, '', layer_dict)
 
         bbox = layer_dict[layer_path].extent()
 

--- a/core/LayerTypes.py
+++ b/core/LayerTypes.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class LayerType(enum.Enum):
+    VECTOR = enum.auto()
+    RASTER = enum.auto()
+    POINTCLOUD = enum.auto()

--- a/core/LoadFiles.py
+++ b/core/LoadFiles.py
@@ -36,7 +36,8 @@ from qgis.core import (Qgis,
 from .Filter import FilterList
 from .QGISLayerTree import QGISLayerTree
 from .Utils import (get_vector_layer,
-                    get_raster_layer)
+                    get_raster_layer,
+                    get_point_cloud_layer)
 
 
 class LoadFiles(ABC):
@@ -350,6 +351,25 @@ class LoadRasters(LoadFiles):
     def _createLayer(self, layer_path, layer_base_name, files_to_load):
         """ Create a raster layer """
         files_to_load[layer_path] = get_raster_layer(layer_path, layer_base_name, files_to_load, True)
+
+        return files_to_load[layer_path]
+
+    def _isEmptyLayer(self, layer_path, layer_dict):
+        """ Do not check this on raster layers """
+        return False
+
+
+class LoadPointClouds(LoadFiles):
+    """ Subclass to load point cloud layers """
+
+    def __init__(self, iface, progressBar, configuration):
+        LoadFiles.__init__(self, iface, progressBar, configuration)
+
+        self.dataType = 'point cloud'
+
+    def _createLayer(self, layer_path, layer_base_name, files_to_load):
+        """ Create a point cloud layer """
+        files_to_load[layer_path] = get_point_cloud_layer(layer_path, layer_base_name, files_to_load, True, self.defaultCrs)
 
         return files_to_load[layer_path]
 

--- a/core/LoadFiles.py
+++ b/core/LoadFiles.py
@@ -22,6 +22,7 @@ import os
 import locale
 from abc import (ABC,
                  abstractmethod)
+import pathlib
 
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import (QApplication,
@@ -77,6 +78,10 @@ class LoadFiles(ABC):
                 try:  # TODO: do we need this in Python 3?
                     # Nasty file names like those created by malware should be caught and ignored
                     extension = str.lower(str(os.path.splitext(file_)[1]))
+                    # check for multiple suffixes - i.e. point clouds can have ".copc.laz"
+                    suffixes = pathlib.Path(file_).suffixes
+                    if len(suffixes) > 1:
+                        extension = "".join(suffixes)
                 except UnicodeEncodeError as e:
                     extension = None
 

--- a/core/LoadFiles.py
+++ b/core/LoadFiles.py
@@ -29,7 +29,8 @@ from qgis.PyQt.QtWidgets import (QApplication,
 from qgis.core import (Qgis,
                        QgsApplication,
                        QgsVectorLayer,
-                       QgsMapLayer)
+                       QgsMapLayer,
+                       QgsCoordinateReferenceSystem)
 
 from .Filter import FilterList
 from .QGISLayerTree import QGISLayerTree
@@ -46,6 +47,8 @@ class LoadFiles(ABC):
         self.iface = iface
         self.files_to_load = dict()  # {'layer_path_1': layer_obj_1, ...}
         self.dataType = ''
+
+        self.defaultCrs: QgsCoordinateReferenceSystem = None
 
         # Configuration parameters
         self.configuration = configuration
@@ -301,6 +304,9 @@ class LoadFiles(ABC):
     def _isEmptyLayer(self, layer_path, layer_dict):
         """ To be overwritten by subclasses """
         pass
+
+    def set_default_crs(self, default_crs: QgsCoordinateReferenceSystem) -> None:
+        self.defaultCrs = default_crs
 
 
 class LoadVectors(LoadFiles):

--- a/core/LoadFiles.py
+++ b/core/LoadFiles.py
@@ -33,6 +33,9 @@ from qgis.core import (Qgis,
                        QgsMapLayer,
                        QgsCoordinateReferenceSystem)
 
+if Qgis.versionInt() >= 31800:
+    from qgis.core import QgsPointCloudLayer
+
 from .Filter import FilterList
 from .QGISLayerTree import QGISLayerTree
 from .Utils import (get_vector_layer,
@@ -374,5 +377,13 @@ class LoadPointClouds(LoadFiles):
         return files_to_load[layer_path]
 
     def _isEmptyLayer(self, layer_path, layer_dict):
-        """ Do not check this on raster layers """
+        if Qgis.versionInt() < 31800:
+            return False
+
+        if layer_dict[layer_path] is None:
+            layer_dict[layer_path] = get_point_cloud_layer(layer_path, '', layer_dict)
+
+        if isinstance(layer_dict[layer_path], QgsPointCloudLayer):
+            if layer_dict[layer_path].dataProvider().pointCount() == 0:
+                return True
         return False

--- a/core/Utils.py
+++ b/core/Utils.py
@@ -19,7 +19,10 @@ email                : gcarrillo@linuxmail.org
  ***************************************************************************/
 """
 from qgis.core import (QgsRasterLayer,
-                       QgsVectorLayer)
+                       QgsVectorLayer,
+                       QgsPointCloudLayer,
+                       QgsCoordinateReferenceSystem,
+                       QgsProviderRegistry)
 
 
 def get_vector_layer(layer_path, layer_name, layer_dict, rename=False):
@@ -38,5 +41,19 @@ def get_raster_layer(layer_path, layer_name, layer_dict, rename=False):
         res = QgsRasterLayer(layer_path, layer_name)
     elif rename:
         res.setName(layer_name)
+
+    return res
+
+
+def get_point_cloud_layer(layer_path, layer_name, layer_dict, rename=False, default_crs: QgsCoordinateReferenceSystem = None):
+    res = layer_dict[layer_path]
+    if res is None:
+        provider = QgsProviderRegistry.instance().preferredProvidersForUri(layer_path)
+        res = QgsPointCloudLayer(layer_path, layer_name, provider[0].metadata().key())
+    elif rename:
+        res.setName(layer_name)
+
+    if default_crs:
+        res.setCrs(default_crs)
 
     return res

--- a/core/Utils.py
+++ b/core/Utils.py
@@ -20,9 +20,12 @@ email                : gcarrillo@linuxmail.org
 """
 from qgis.core import (QgsRasterLayer,
                        QgsVectorLayer,
-                       QgsPointCloudLayer,
                        QgsCoordinateReferenceSystem,
-                       QgsProviderRegistry)
+                       QgsProviderRegistry,
+                       Qgis)
+
+if Qgis.versionInt() >= 31800:
+    from qgis.core import QgsPointCloudLayer
 
 
 def get_vector_layer(layer_path, layer_name, layer_dict, rename=False):
@@ -46,6 +49,9 @@ def get_raster_layer(layer_path, layer_name, layer_dict, rename=False):
 
 
 def get_point_cloud_layer(layer_path, layer_name, layer_dict, rename=False, default_crs: QgsCoordinateReferenceSystem = None):
+    if Qgis.versionInt() < 31800:
+        return None
+
     res = layer_dict[layer_path]
     if res is None:
         provider = QgsProviderRegistry.instance().preferredProvidersForUri(layer_path)

--- a/core/Utils.py
+++ b/core/Utils.py
@@ -117,3 +117,13 @@ def get_parent_folder(layer_path):
     parts = QgsProviderRegistry.instance().decodeUri('ogr', layer_path)
     return os.path.dirname(parts['path'])
 
+
+def has_point_cloud_provider() -> bool:
+    qgis_providers = QgsProviderRegistry.instance().providerList()
+    point_cloud_providers = QgsProviderRegistry.instance().providersForLayerType(Qgis.LayerType.PointCloud)
+    if not point_cloud_providers:
+        return False
+    for point_cloud_provider in point_cloud_providers:
+        if point_cloud_provider in qgis_providers:
+            return True
+    return False

--- a/core/Utils.py
+++ b/core/Utils.py
@@ -56,6 +56,8 @@ def get_point_cloud_layer(layer_path, layer_name, layer_dict, rename=False, defa
     res = layer_dict[layer_path]
     if res is None:
         provider = QgsProviderRegistry.instance().preferredProvidersForUri(layer_path)
+        if not provider:
+            return None
         res = QgsPointCloudLayer(layer_path, layer_name, provider[0].metadata().key())
     elif rename:
         res.setName(layer_name)

--- a/gui/BaseLoadThemAllDialog.py
+++ b/gui/BaseLoadThemAllDialog.py
@@ -18,14 +18,22 @@ email                : gcarrillo@linuxmail.org
  *                                                                         *
  ***************************************************************************/
 """
+import enum
+
 from qgis.PyQt.QtCore import (Qt,
                               QSettings)
 from qgis.PyQt.QtWidgets import (QApplication,
                                  QDialog,
                                  QFileDialog)
 
-from ..core.FileFormatConfiguration import VECTOR_FORMATS, RASTER_FORMATS
+from ..core.FileFormatConfiguration import VECTOR_FORMATS, RASTER_FORMATS, POINT_CLOUD_FORMATS
 from ..ui.Ui_Base_LoadThemAll import Ui_Base_LoadThemAll
+
+
+class LayerType(enum.Enum):
+    VECTOR = enum.auto()
+    RASTER = enum.auto()
+    POINTCLOUD = enum.auto()
 
 
 class BaseLoadThemAllDialog(QDialog, Ui_Base_LoadThemAll):

--- a/gui/BaseLoadThemAllDialog.py
+++ b/gui/BaseLoadThemAllDialog.py
@@ -18,7 +18,6 @@ email                : gcarrillo@linuxmail.org
  *                                                                         *
  ***************************************************************************/
 """
-import enum
 
 from qgis.PyQt.QtCore import (Qt,
                               QSettings)
@@ -27,13 +26,8 @@ from qgis.PyQt.QtWidgets import (QApplication,
                                  QFileDialog)
 
 from ..core.FileFormatConfiguration import VECTOR_FORMATS, RASTER_FORMATS, POINT_CLOUD_FORMATS
+from ..core.LayerTypes import LayerType
 from ..ui.Ui_Base_LoadThemAll import Ui_Base_LoadThemAll
-
-
-class LayerType(enum.Enum):
-    VECTOR = enum.auto()
-    RASTER = enum.auto()
-    POINTCLOUD = enum.auto()
 
 
 class BaseLoadThemAllDialog(QDialog, Ui_Base_LoadThemAll):

--- a/gui/LoadThemAllDialog.py
+++ b/gui/LoadThemAllDialog.py
@@ -35,6 +35,7 @@ from ..core.Filter import (AlphanumericFilter,
                            InvertedAlphanumericFilter,
                            RasterTypeFilter)
 from ..core.LoadFiles import *
+from ..core.Utils import has_point_cloud_provider
 from ..ui.Ui_DockWidget import Ui_DockWidget
 
 
@@ -72,7 +73,7 @@ class LoadThemAllDialog(QDockWidget, Ui_DockWidget):
         self.btnCancel.setVisible(False)
         self.btnCancel.clicked.connect(self.cancelLoad)
 
-        if Qgis.versionInt() < 31800:
+        if Qgis.versionInt() < 31800 and has_point_cloud_provider():
             self.tabWidget.widget(2).setEnabled(False)
 
     def updateControls(self):

--- a/gui/LoadThemAllDialog.py
+++ b/gui/LoadThemAllDialog.py
@@ -70,6 +70,9 @@ class LoadThemAllDialog(QDockWidget, Ui_DockWidget):
         self.btnCancel.setVisible(False)
         self.btnCancel.clicked.connect(self.cancelLoad)
 
+        if Qgis.versionInt() < 31800:
+            self.tabWidget.widget(2).setEnabled(False)
+
     def updateControls(self):
         """ Read stored settings and put them into the appropriate tab """
         settings = QSettings()

--- a/gui/LoadThemAllDialog.py
+++ b/gui/LoadThemAllDialog.py
@@ -25,7 +25,8 @@ from qgis.PyQt.QtWidgets import (QDockWidget,
 from qgis.core import (QgsRectangle,
                        Qgis)
 
-from .BaseLoadThemAllDialog import BaseLoadThemAllDialog, LayerType
+from .BaseLoadThemAllDialog import BaseLoadThemAllDialog
+from ..core.LayerTypes import LayerType
 from ..core.LoadConfiguration import LoadConfiguration
 from ..core.Filter import (AlphanumericFilter,
                            BoundingBoxFilter,
@@ -224,9 +225,9 @@ class LoadThemAllDialog(QDockWidget, Ui_DockWidget):
                     # Bounding Box Filter (part 2 out of 2)
                     if bBoundingBoxFilter is True:
                         if self.dlgBase.radContains.isChecked():
-                            filter = BoundingBoxFilter("vector", extent, "contains")
+                            filter = BoundingBoxFilter(LayerType.VECTOR, extent, "contains")
                         else:
-                            filter = BoundingBoxFilter("vector", extent, "intersects")
+                            filter = BoundingBoxFilter(LayerType.VECTOR, extent, "intersects")
                         filterList.addFilter(filter)
 
                     loader = LoadVectors(self.iface, self.progressBar, configuration)
@@ -255,9 +256,9 @@ class LoadThemAllDialog(QDockWidget, Ui_DockWidget):
                     # Bounding Box Filter (part 2 out of 2)
                     if bBoundingBoxFilter is True:
                         if self.dlgBase.radContains.isChecked():
-                            filter = BoundingBoxFilter("raster", extent, "contains")
+                            filter = BoundingBoxFilter(LayerType.RASTER, extent, "contains")
                         else:
-                            filter = BoundingBoxFilter("raster", extent, "intersects")
+                            filter = BoundingBoxFilter(LayerType.RASTER, extent, "intersects")
                         filterList.addFilter(filter)
 
                     loader = LoadRasters(self.iface, self.progressBar, configuration)
@@ -273,9 +274,9 @@ class LoadThemAllDialog(QDockWidget, Ui_DockWidget):
                     # Bounding Box Filter (part 2 out of 2)
                     if bBoundingBoxFilter is True:
                         if self.dlgBase.radContains.isChecked():
-                            filter = BoundingBoxFilter("pointcloud", extent, "contains")
+                            filter = BoundingBoxFilter(LayerType.POINTCLOUD, extent, "contains")
                         else:
-                            filter = BoundingBoxFilter("pointcloud", extent, "intersects")
+                            filter = BoundingBoxFilter(LayerType.POINTCLOUD, extent, "intersects")
                         filterList.addFilter(filter)
 
                     loader = LoadPointClouds(self.iface, self.progressBar, configuration)

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,7 +2,7 @@
 name=Load Them All
 description=Loads files stored in a directory structure recursively, based on several filters
 about=QGIS plugin that recursively loads vector and raster layers stored in a directory structure, based on several filters.
-version=3.4
+version=3.5
 qgisMinimumVersion=3.0
 category=Layers
 author=Germán Carrillo (GeoTux)

--- a/ui/Ui_DockWidget.ui
+++ b/ui/Ui_DockWidget.ui
@@ -269,6 +269,92 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="tabPointCloud">
+       <attribute name="title">
+        <string>Point Cloud</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QScrollArea" name="scrollArea_2">
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="horizontalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOff</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents_4">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>-101</y>
+             <width>323</width>
+             <height>574</height>
+            </rect>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_11">
+            <item row="0" column="0">
+             <widget class="QStackedWidget" name="stackedWidgetPointCloud">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>488</height>
+               </size>
+              </property>
+              <widget class="QWidget" name="page_7"/>
+              <widget class="QWidget" name="page_8"/>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QGroupBox" name="groupBoxPointCloudsCrs">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="title">
+               <string>Set CRS to all Point Cloud Layers</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_10">
+               <property name="leftMargin">
+                <number>10</number>
+               </property>
+               <property name="topMargin">
+                <number>9</number>
+               </property>
+               <property name="bottomMargin">
+                <number>9</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QgsProjectionSelectionWidget" name="pointCloudCrs"/>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+       </layout>
+      </widget>
       <widget class="QWidget" name="tabConfiguration">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -1102,5 +1188,12 @@ same folder name (e.g., my_group.qml), it will be applied to all layers inside t
    </layout>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+  </customwidget>
+ </customwidgets>
  <connections/>
 </ui>


### PR DESCRIPTION
Firstly I would to give thumbs up :+1:  for the plugin, I have been using it for quite some time and it is quite awesome.

This adds support for Point Cloud Layers which are part of QGIS since 3.18. Point clouds tends to come in large number of files and option to load them in batch is very useful. The functionally will the disabled for QGIS versions older then 3.18 and it should not cause troubles as the imports checks for versions. 

I tried to follow the general style of the plugin as closely as possible. However, I had to create an enum for layer type as the current code was either vector or raster in some places and did not expect possible third option.

The functionality for Point Cloud Layers is the same as for all other layers. The only think that I added is an option to set CRS for all loaded Point Cloud Layers as these files quite often come without CRS specified and setting the manually is quite a problem, especially if there are many files.

Let me know, if there is anything that you would like to change in this PR :) 

----------------

(References #25)
